### PR TITLE
Update ksonnet-lib dependency to beta.2

### DIFF
--- a/Formula/ksonnetlib.rb
+++ b/Formula/ksonnetlib.rb
@@ -2,8 +2,8 @@ class Ksonnetlib < Formula
   desc "Standard library for kubecfg"
   homepage "http://ksonnet.heptio.com/"
   url "https://github.com/ksonnet/ksonnet-lib.git",
-    :tag => "beta.1",
-    :revision => "56ad544bfcfeea417fe50eb80c49505399ee37d3"
+    :tag => "beta.2",
+    :revision => "9f6e7b23e20dc0721cec8f5933e4f8692c5a30b6"
   head "https://github.com/ksonnet/ksonnet-lib.git"
 
   def install
@@ -11,6 +11,7 @@ class Ksonnetlib < Formula
     libdir.mkpath
     libdir.install "ksonnet.alpha.1"
     libdir.install "ksonnet.beta.1"
+    libdir.install "ksonnet.beta.2"
   end
 
   def caveats


### PR DESCRIPTION
I am not a `brew` native, so this might not be correct, but I have attempted to update the ksonnet-lib dependency to beta.2, which is the first prod-ready release.

Another thing you might consider in the future is to copy the `ksonnet.beta.2` folder in to `/usr/share/${jsonnet_version}/`, so that you don't have to compile it using `-J` flags. See, for example, our [Dockerfile](https://github.com/ksonnet/ksonnet-lib/blob/master/Dockerfile#L26).